### PR TITLE
Wrap call to destroy

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function promisify(fn) {
 });
 
 
+Client.prototype.destroy = function () { this.client.destroy(); };
 Client.prototype._search = promisify('search');
 
 


### PR DESCRIPTION
As per https://github.com/mcavage/node-ldapjs/issues/318 , sometimes you will need to call destroy to completely close a client connection so you don't idle error out after ~17 minutes.
