### PR TITLE
Resolve promise on size limit 'error'

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ Client.prototype.search = function (base, options, controls) {
     var searchCallback = function (err, result) {
       var r = {
         entries: [],
+        hitSizeLimit: false,
         references: []
       };
 
@@ -53,6 +54,12 @@ Client.prototype.search = function (base, options, controls) {
       });
 
       result.on('error', function (err) {
+        if (options.sizeLimit && err.name === 'SizeLimitExceededError') {
+          // Swallow error on limiting result size if we are limited
+          // See https://github.com/mcavage/node-ldapjs/issues/236
+          r.hitSizeLimit = true
+          resolve(r);
+        }
         reject(err);
       });
 


### PR DESCRIPTION
Previously, a `SizeLimitExceededError` (aka the ["expected" result](https://github.com/mcavage/node-ldapjs/issues/236) for setting a limit on number of results) would cause the Promise to be rejected.  This PR adds a check on whether the search had a sizeLimit and if it did, then take the error as a signal to say "I'm done" and resolve instead.  For downstream code, I added a `hitSizeLimit` flag on the result so it's possible to still resolve the Promise but still know whether the result set was caused by hitting the limit.

Looking at the list of errors (http://ldapjs.org/errors.html), this seems to be the only "error" that is actually a signal to success.