### PR TITLE
Client.search: reject promise on undefined result

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,10 @@ Client.prototype.search = function (base, options, controls) {
 
   return new Promise(function (resolve, reject) {
     var searchCallback = function (err, result) {
+      if (result === undefined) {
+        reject(err);
+      }
+
       var r = {
         entries: [],
         references: []


### PR DESCRIPTION
This fixes a bug we'd noticed where [certain upstream errors](https://github.com/joyent/node-ldapjs/blob/bb2d018b2c6e9cdfba7102091b8a2008f37d4f2c/lib/client/client.js#L1433-L1436) are handled by returning only a single result, instead of two. We were seeing unexpectedly-handled promises as a result of this.